### PR TITLE
Upgraded Exporter and other Projects to net8 exclusive

### DIFF
--- a/Source/Translatable.Export.Shared/Translatable.Export.Shared.csproj
+++ b/Source/Translatable.Export.Shared/Translatable.Export.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Translatable.Export/Translatable.Export.csproj
+++ b/Source/Translatable.Export/Translatable.Export.csproj
@@ -1,11 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseWPF>True</UseWPF>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Translatable.Export.Shared\Translatable.Export.Shared.csproj" />
   </ItemGroup>

--- a/Source/Translatable.NGettext/Translatable.NGettext.csproj
+++ b/Source/Translatable.NGettext/Translatable.NGettext.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -19,10 +19,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Translatable\Translatable.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/Source/Translatable/Translatable.csproj
+++ b/Source/Translatable/Translatable.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -17,9 +17,5 @@
     <AssemblyVersion>0.2.0</AssemblyVersion>
     <FileVersion>0.2.0</FileVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/Source/TranslationTest/Translatable.SampleProject.csproj
+++ b/Source/TranslationTest/Translatable.SampleProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Translatable.SampleProject</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Source/UnitTest/Translatable.Export.UnitTest/Translatable.Export.UnitTest.csproj
+++ b/Source/UnitTest/Translatable.Export.UnitTest/Translatable.Export.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>Translatable.Export.UnitTest</AssemblyTitle>
@@ -10,15 +10,11 @@
     <AssemblyVersion>0.2.0</AssemblyVersion>
     <FileVersion>0.2.0</FileVersion>
     <OutputType>Library</OutputType>
-	<IsTestProject>true</IsTestProject>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Translatable.Export\Translatable.Export.csproj" />
     <ProjectReference Include="..\..\Translatable\Translatable.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/Source/UnitTest/Translatable.UnitTest/Translatable.UnitTest.csproj
+++ b/Source/UnitTest/Translatable.UnitTest/Translatable.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>Translatable.UnitTest</AssemblyTitle>
@@ -13,11 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Translatable.NGettext\Translatable.NGettext.csproj" />
     <ProjectReference Include="..\..\Translatable\Translatable.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Had issues to export from net8 dlls since type were missings. Had to set Exporter to be a windows application and uncluding wpf to cover all the missing types ( PresentationFramework was missing)